### PR TITLE
Changes to ceqlorenz and ceqefext

### DIFF
--- a/ceqlorenz.ado
+++ b/ceqlorenz.ado
@@ -677,8 +677,9 @@ program define ceqlorenz, rclass
 								matrix frontmatter[`=`row'+`i'',`_`v''] = .
 							}
 						}
-						local row = `row' + 3 // want to add three whether or not `p' option specified since those matrices are in the MWB
+						
 					}
+				local row = `row' + 3 // want to add three whether or not `p' option specified since those matrices are in the MWB
 				}
 			}
 		}


### PR DESCRIPTION
Fixed printer error for ceqlorenz, it was print poverty lines in th wrong cells. Fixed warnings produced by ceqefext for when programs exceed income and left _ceqspend to be missing until we finish the modifications.