### PR TITLE
ceqmarg sep5, 2018

### DIFF
--- a/tests/dofiles/test-issue#36.do
+++ b/tests/dofiles/test-issue#36.do
@@ -25,14 +25,10 @@ local income_options_SA1
 	market(ym_SA1)
 	/*mpluspensions(yp_SA1)
 	netmarket(yn_SA1)
-	gross(yg_SA1) */
+	gross(yg_SA1)
 	disposable(yd_SA1)
-	/*consumable(yc_SA1)
+	consumable(yc_SA1)
 	final(yf_SA1)*/;
-local test_interventions
-	dtaxes(pc_income_taxes_test)
-;
-	
 local direct_options_SA1
 	pensions(pc_contributory_pen)
 	dtransfers(
@@ -79,37 +75,22 @@ sample 0.1
 
 count
 replace pc_energy_subsidies = - pc_energy_subsidies in 1/20
-gen pc_income_taxes_test = pc_income_taxes 
-replace pc_income_taxes_test = - pc_income_taxes in 1/40
-
 
 **********
 ** TEST **
 **********
 
 #delimit ;
-/*
-ceqextend_jun9 using "MEX_NAT_Reruns_CEQMWB2017_E12_2011PPP_Feb07_2018.xlsx",
+
+
+	ceqmarg_sep5 using "MEX_NAT_Reruns_CEQMWB2017_E13_2011PPP_Feb07_2018.xlsx",
 	`income_options_SA1'
+	negatives
 	ppp(1)
 	cpibase(103.15684)
 	cpisurvey(108.69572)	
-	negatives
 	/*`direct_options_SA1'*/
 	`indirect_options'
-	/*`inkind_options'*/
-	hhid(code_uc);
-*/
-
-	ceqmarg_test using "MEX_NAT_Reruns_CEQMWB2017_E13_2011PPP_Feb07_2018.xlsx",
-	`income_options_SA1'
-	negatives
-	ppp(1)
-	cpibase(103.15684)
-	cpisurvey(108.69572)	
-	/*`direct_options_SA1'*/
-	`test_interventions'
-	/*`indirect_options'*/
 	/*`inkind_options'*/
 	hhid(code_uc);
 

--- a/tests/logs/test-issue#36.log
+++ b/tests/logs/test-issue#36.log
@@ -2,7 +2,7 @@
       name:  <unnamed>
        log:  C:\Users\Rosie\Dropbox\CEQ_ado\test-issue#36.log
   log type:  text
- opened on:   1 Jul 2018, 17:27:30
+ opened on:   5 Sep 2018, 22:00:40
 
 . version 13.0
 
@@ -22,16 +22,12 @@ delimiter now ;
 >         market(ym_SA1)
 >         /*mpluspensions(yp_SA1)
 >         netmarket(yn_SA1)
->         gross(yg_SA1) */
+>         gross(yg_SA1)
 >         disposable(yd_SA1)
->         /*consumable(yc_SA1)
+>         consumable(yc_SA1)
 >         final(yf_SA1)*/;
 
-. local test_interventions
->         dtaxes(pc_income_taxes_test)
-> ;
-
-.         local direct_options_SA1
+. local direct_options_SA1
 >         pensions(pc_contributory_pen)
 >         dtransfers(
 >                 pc_BolsaFamilia 
@@ -91,12 +87,6 @@ delimiter now cr
 . replace pc_energy_subsidies = - pc_energy_subsidies in 1/20
 (9 real changes made)
 
-. gen pc_income_taxes_test = pc_income_taxes 
-
-. replace pc_income_taxes_test = - pc_income_taxes in 1/40
-(11 real changes made)
-
-. 
 . 
 . **********
 . ** TEST **
@@ -104,45 +94,30 @@ delimiter now cr
 . 
 . #delimit ;
 delimiter now ;
-. /*
-> ceqextend_jun9 using "MEX_NAT_Reruns_CEQMWB2017_E12_2011PPP_Feb07_2018.xlsx",
+.         ceqmarg_sep5 using "MEX_NAT_Reruns_CEQMWB2017_E13_2011PPP_Feb07_2018.xlsx",
 >         `income_options_SA1'
+>         negatives
 >         ppp(1)
 >         cpibase(103.15684)
 >         cpisurvey(108.69572)    
->         negatives
 >         /*`direct_options_SA1'*/
 >         `indirect_options'
 >         /*`inkind_options'*/
 >         hhid(code_uc);
-> */
-> 
->         ceqmarg_test using "MEX_NAT_Reruns_CEQMWB2017_E13_2011PPP_Feb07_2018.xlsx",
->         `income_options_SA1'
->         negatives
->         ppp(1)
->         cpibase(103.15684)
->         cpisurvey(108.69572)    
->         /*`direct_options_SA1'*/
->         `test_interventions'
->         /*`indirect_options'*/
->         /*`inkind_options'*/
->         hhid(code_uc);
-Running version 1.7 of ceqmarg on  1 Jul 2018 at 17:27:30
+Running version 1.7 of ceqmarg on  5 Sep 2018 at 22:00:42
    (please report this information if reporting a bug to sean.higgins@ceqinstitute.org)
-Warning: variable pc_income_taxes_test not labeled
+Warning: Fiscal intervention variable(s) pc_energy_subsidies not stored in double format. This may lead to subs
+> tantial discrepancies in the MWB due to rounding error.
 Warning: daily, monthly, or yearly options not specified; variables assumed to be in yearly local currency unit
 > s
-Warning: 11 negative values of pc_income_taxes_test. Concentration Coefficient, Kakwani Index, and Marginal Con
-> tribution are not well behaved.
-Warning: 11 negative values of All direct taxes. Concentration Coefficient, Kakwani Index, and Marginal Contrib
-> ution are not well behaved.
-Warning: 11 negative values of All direct taxes and contributions. Concentration Coefficient, Kakwani Index, an
-> d Marginal Contribution are not well behaved.
-Warning: 11 negative values of All taxes. Concentration Coefficient, Kakwani Index, and Marginal Contribution a
-> re not well behaved.
-Warning: 11 negative values of All taxes and contributions. Concentration Coefficient, Kakwani Index, and Margi
-> nal Contribution are not well behaved.
+Warning: 9 negative values of Energy subsidies - TSEE (household per capita). Concentration Coefficient, Kakwan
+> i Index, and Marginal Contribution are not well behaved.
+Warning: 9 negative values of All indirect subsidies. Concentration Coefficient, Kakwani Index, and Marginal Co
+> ntribution are not well behaved.
+Warning: 9 negative values of All net transfers and subsidies excl contributory pensions. Concentration Coeffic
+> ient, Kakwani Index, and Marginal Contribution are not well behaved.
+Warning: 9 negative values of All net transfers and subsidies incl contributory pensions. Concentration Coeffic
+> ient, Kakwani Index, and Marginal Contribution are not well behaved.
 Writing to "MEX_NAT_Reruns_CEQMWB2017_E13_2011PPP_Feb07_2018.xlsx"; may take several minutes
 
 . #delimit cr     
@@ -170,5 +145,5 @@ delimiter now cr
       name:  <unnamed>
        log:  C:\Users\Rosie\Dropbox\CEQ_ado\test-issue#36.log
   log type:  text
- closed on:   1 Jul 2018, 17:27:32
+ closed on:   5 Sep 2018, 22:00:46
 ---------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This version fixes the following issue: negative options did not work when income without the intervention has negative values. With this fix, the ceqmarg measures won't be calculated when income without the intervention has negative values.